### PR TITLE
Fix isNotFound and isForbidden methods

### DIFF
--- a/pkg/controller/provider/container/openstack/client.go
+++ b/pkg/controller/provider/container/openstack/client.go
@@ -617,28 +617,23 @@ func (r *Client) get(object interface{}, ID string) (err error) {
 }
 
 func (r *Client) isNotFound(err error) bool {
-	switch liberr.Unwrap(err).(type) {
-	case gophercloud.ErrResourceNotFound, gophercloud.ErrDefault404:
-		return true
+	switch unWrapErr := liberr.Unwrap(err).(type) {
 	case gophercloud.ErrUnexpectedResponseCode:
-		if gopherlcoudErr, ok := liberr.Unwrap(err).(gophercloud.ErrUnexpectedResponseCode); ok {
-			if gopherlcoudErr.GetStatusCode() == http.StatusNotFound {
-				return true
-			}
+		if unWrapErr.GetStatusCode() == http.StatusNotFound {
+			return true
 		}
-		return false
-	default:
-		return false
 	}
+	return false
 }
 
 func (r *Client) isForbidden(err error) bool {
-	switch liberr.Unwrap(err).(type) {
-	case gophercloud.ErrDefault403:
-		return true
-	default:
-		return false
+	switch unWrapErr := liberr.Unwrap(err).(type) {
+	case gophercloud.ErrUnexpectedResponseCode:
+		if unWrapErr.GetStatusCode() == http.StatusForbidden {
+			return true
+		}
 	}
+	return false
 }
 
 func (r *Client) getAuthenticatedUserID() (string, error) {


### PR DESCRIPTION
Unwrapping the error converts all the gophercloud errors to gophercloud.ErrUnexpectedResponse type so it does not make sense to check ErrDefault404, ErrResourceNotFound  and ErrDefault403. We will check the status code instead.